### PR TITLE
feat!: change to conventionalcommits

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,8 +1,18 @@
 module.exports = {
     branches: "main",
     plugins: [
-        "@semantic-release/commit-analyzer",
-        "@semantic-release/release-notes-generator",
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                preset: "conventionalcommits",
+            },
+        ],
+        [
+            "@semantic-release/release-notes-generator",
+            {
+                preset: "conventionalcommits",
+            },
+        ],
         [
             "@semantic-release/changelog",
             {


### PR DESCRIPTION
It seems the 'Angular' default for commit messages does not notice
a '!' to indicate a breaking change.

So, we have switched to `conventionalcommits`, instead.